### PR TITLE
Add decile price labels

### DIFF
--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -22,14 +22,16 @@ noctua_options(unload = TRUE)
 
 AWS_ATHENA_CONN_NOCTUA <- dbConnect(noctua::athena(), rstudio_conn_tab = FALSE)
 
+year <- format(Sys.Date(), "%Y")
+
 # These files live on the O drive in
 # O:/CCAODATA/recurring-data-requests/provisional-ratio-curves/. Since
 # that isn't accessible from the server they need to be copied locally or run
 # from a local machine. They MUST be named according to the current naming
 # scheme, and there must be PIN and Desk Review Value columns
 data_path <- "O:/CCAODATA/recurring-data-requests/provisional-ratio-curves/"
-input_path <- file.path(data_path, "input")
-output_path <- file.path(data_path, "output")
+input_path <- file.path(data_path, "input", year)
+output_path <- file.path(data_path, "output", year)
 files_in <- list.files(input_path, full.names = TRUE)
 
 # Flatfile ----

--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -126,6 +126,23 @@ walk(unique(all_ratios$township_name), \(x) {
       values_to = "Sale Ratio"
     )
 
+  # Build x-axis labels with abbreviated price ranges per decile
+  axis_labels <- output$`All Parcels` %>%
+    filter(!is.na(`Sale Price`)) %>%
+    summarize(
+      min_price = min(`Sale Price`),
+      max_price = max(`Sale Price`),
+      .by = `Price Decile`
+    ) %>%
+    arrange(`Price Decile`) %>%
+    mutate(label = paste0(
+      `Price Decile`, "\n",
+      scales::dollar(min_price, scale_cut = scales::cut_short_scale()),
+      "\u2013",
+      scales::dollar(max_price, scale_cut = scales::cut_short_scale())
+    )) %>%
+    { setNames(.$label, .$`Price Decile`) }
+
   # Graph ----
 
   # Create ratio curves for both stages
@@ -165,7 +182,7 @@ walk(unique(all_ratios$township_name), \(x) {
         by = 0.1
       )
     ) +
-    scale_x_continuous(breaks = seq(1, 10, by = 1)) +
+    scale_x_continuous(breaks = seq(1, 10, by = 1), labels = axis_labels) +
     ggtitle(
       label = paste0("Sale Ratios for ", x, " Township"),
       subtitle = "Model and Desk Review Values"

--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -141,7 +141,9 @@ walk(unique(all_ratios$township_name), \(x) {
       "\u2013",
       scales::dollar(max_price, scale_cut = scales::cut_short_scale())
     )) %>%
-    { setNames(.$label, .$`Price Decile`) }
+    {
+      setNames(.$label, .$`Price Decile`)
+    }
 
   # Graph ----
 

--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -27,9 +27,10 @@ AWS_ATHENA_CONN_NOCTUA <- dbConnect(noctua::athena(), rstudio_conn_tab = FALSE)
 # that isn't accessible from the server they need to be copied locally or run
 # from a local machine. They MUST be named according to the current naming
 # scheme, and there must be PIN and Desk Review Value columns
-data_path <- "/home/miwagne/repos/recurring-data-requests/provisional-ratio-curves/"
+data_path <- "O:/CCAODATA/recurring-data-requests/provisional-ratio-curves/"
+input_path <- file.path(data_path, "input")
 output_path <- file.path(data_path, "output")
-files_in <- file.path(data_path, "33-river_forest.xlsx")
+files_in <- list.files(input_path, full.names = TRUE)
 
 # Flatfile ----
 

--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -27,10 +27,9 @@ AWS_ATHENA_CONN_NOCTUA <- dbConnect(noctua::athena(), rstudio_conn_tab = FALSE)
 # that isn't accessible from the server they need to be copied locally or run
 # from a local machine. They MUST be named according to the current naming
 # scheme, and there must be PIN and Desk Review Value columns
-data_path <- "O:/CCAODATA/recurring-data-requests/provisional-ratio-curves/"
-input_path <- file.path(data_path, "input")
+data_path <- "/home/miwagne/repos/recurring-data-requests/provisional-ratio-curves/"
 output_path <- file.path(data_path, "output")
-files_in <- list.files(input_path, full.names = TRUE)
+files_in <- file.path(data_path, "33-river_forest.xlsx")
 
 # Flatfile ----
 
@@ -138,7 +137,7 @@ walk(unique(all_ratios$township_name), \(x) {
     mutate(label = paste0(
       `Price Decile`, "\n",
       scales::dollar(min_price, scale_cut = scales::cut_short_scale()),
-      "\u2013",
+      "\u2013\n",
       scales::dollar(max_price, scale_cut = scales::cut_short_scale())
     )) %>%
     {
@@ -177,6 +176,7 @@ walk(unique(all_ratios$township_name), \(x) {
     geom_line(linewidth = 1) +
     geom_label(show.legend = FALSE) +
     theme_minimal() +
+    theme(axis.text.x = element_text(size = 8)) +
     coord_cartesian(ylim = c(y_min, y_max)) +
     scale_y_continuous(
       breaks = seq(floor(y_min * 10) / 10,

--- a/provisional-ratio-curves/provisional-ratio-curves.sql
+++ b/provisional-ratio-curves/provisional-ratio-curves.sql
@@ -8,7 +8,8 @@ WITH final_models AS (
         UNNEST(final_model.township_code_coverage) AS towns (township_code)
     -- Year will need to be adjusted so that desk review to model values join in
     -- R script is 1 to 1.
-    WHERE final_model.year = '2026' AND final_model.type = 'res'
+    WHERE final_model.year = CAST(YEAR(CURRENT_DATE) AS VARCHAR)
+        AND final_model.type = 'res'
 ),
 
 -- Use final model run IDs to grab the model values we need to compare Res Val's
@@ -40,7 +41,10 @@ most_recent_pin AS (
             ORDER BY uni.year DESC
         ) AS rank
     FROM default.vw_pin_universe AS uni
-    WHERE uni.year IN ('2025', '2026')
+    WHERE uni.year IN (
+            CAST(YEAR(CURRENT_DATE) - 1 AS VARCHAR),
+            CAST(YEAR(CURRENT_DATE) AS VARCHAR)
+        )
 )
 
 SELECT


### PR DESCRIPTION
A stakeholder requested price decile labels on the ratio curve output. The best strategy I could come up with to reduce overlapping was to put the min and max on separate lines

Here is an example output:
<img width="365" height="72" alt="axis_price_decile_example" src="https://github.com/user-attachments/assets/e308cce7-47e2-4328-8014-30240c1fe962" />
