### PR TITLE
Record any sales that are not included in desk review sales ratios

### DIFF
--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -51,7 +51,7 @@ dr_vals <- map(files_in, \(x) {
 # based on the first two characters of the file name, which should be the
 # township code. Input files *must* be named correctly.
 dr_towns <- substr(basename(files_in), 1, 2)
-if (!any(dr_towns %in% ccao::town_dict$township_code)) {
+if (!all(dr_towns %in% ccao::town_dict$township_code)) {
   stop("One or more township codes in the input files are not valid.")
 }
 

--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -8,6 +8,7 @@ library(DBI)
 library(dplyr)
 library(ggplot2)
 library(ggspatial)
+library(glue)
 library(noctua)
 library(openxlsx)
 library(prettymapr)
@@ -19,7 +20,6 @@ library(sf)
 library(tidyr)
 
 noctua_options(unload = TRUE)
-
 AWS_ATHENA_CONN_NOCTUA <- dbConnect(noctua::athena(), rstudio_conn_tab = FALSE)
 
 year <- format(Sys.Date(), "%Y")
@@ -29,10 +29,10 @@ year <- format(Sys.Date(), "%Y")
 # that isn't accessible from the server they need to be copied locally or run
 # from a local machine. They MUST be named according to the current naming
 # scheme, and there must be PIN and Desk Review Value columns
-data_path <- "O:/CCAODATA/recurring-data-requests/provisional-ratio-curves/"
+data_path <- "O:/CCAODATA/recurring-data-requests/provisional-ratio-curves"
 input_path <- file.path(data_path, "input", year)
 output_path <- file.path(data_path, "output", year)
-files_in <- list.files(input_path, full.names = TRUE)
+files_in <- list.files(input_path, full.names = TRUE, pattern = "\\.xlsx$")
 
 # Flatfile ----
 
@@ -47,15 +47,34 @@ dr_vals <- map(files_in, \(x) {
 }) %>%
   bind_rows()
 
+# Grab a list of all towns we're processing to use in the SQL query. This is
+# based on the first two characters of the file name, which should be the
+# township code. Input files *must* be named correctly.
+dr_towns <- substr(basename(files_in), 1, 2)
+if (!any(dr_towns %in% ccao::town_dict$township_code)) {
+  stop("One or more township codes in the input files are not valid.")
+}
+
 # This SQL query will return townships, neighborhoods, and model values for
 # every PIN, as well as any associated sales used for training
 model_vals <- dbGetQuery(
-  conn = AWS_ATHENA_CONN_NOCTUA, read_file("provisional-ratio-curves.sql")
+  conn = AWS_ATHENA_CONN_NOCTUA,
+  glue_sql(
+    read_file("provisional-ratio-curves.sql"),
+    .con = AWS_ATHENA_CONN_NOCTUA
+  )
 )
 
 # Attach dr and model values to calculate ratios
 all_ratios <- dr_vals %>%
-  left_join(model_vals)
+  # Valuations provides a bunch of parcels of classes that are not part of the
+  # modeling pipeline. We strip these parcels out of the analysis.
+  inner_join(
+    model_vals %>%
+      select(pin)
+  ) %>%
+  full_join(model_vals, by = "pin") %>%
+  mutate(sale_excluded = is.na(desk_review_value) & !is.na(sale_price))
 
 walk(unique(all_ratios$township_name), \(x) {
   # Construct list for outputting multisheet .xlsx

--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -74,7 +74,7 @@ all_ratios <- dr_vals %>%
       select(pin)
   ) %>%
   full_join(model_vals, by = "pin") %>%
-  # Define an excluded a sale as one that has a sale price but no provided desk
+  # Define an excluded sale as one that has a sale price but no provided desk
   # review value.
   mutate(sale_excluded = is.na(desk_review_value) & !is.na(sale_price))
 

--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -74,6 +74,8 @@ all_ratios <- dr_vals %>%
       select(pin)
   ) %>%
   full_join(model_vals, by = "pin") %>%
+  # Define an excluded a sale as one that has a sale price but no provided desk
+  # review value.
   mutate(sale_excluded = is.na(desk_review_value) & !is.na(sale_price))
 
 walk(unique(all_ratios$township_name), \(x) {

--- a/provisional-ratio-curves/provisional-ratio-curves.sql
+++ b/provisional-ratio-curves/provisional-ratio-curves.sql
@@ -41,8 +41,8 @@ most_recent_pin AS (
             ORDER BY uni.year DESC
         ) AS rank
     FROM default.vw_pin_universe AS uni
-    -- Make sure we only grab parcels valued by the res avm, for the towns
-    -- we're processing.
+    -- Make sure we only grab parcels valued by the res avm, for the towns we're
+    -- processing.
     INNER JOIN ccao.class_dict
         ON uni.class = class_dict.class_code
         AND class_dict.modeling_group IN ('SF', 'MF', 'BB')

--- a/provisional-ratio-curves/provisional-ratio-curves.sql
+++ b/provisional-ratio-curves/provisional-ratio-curves.sql
@@ -41,15 +41,14 @@ most_recent_pin AS (
             ORDER BY uni.year DESC
         ) AS rank
     FROM default.vw_pin_universe AS uni
+    -- Make sure we only grab parcels valued by the res avm, for the towns
+    -- we're processing.
+    INNER JOIN ccao.class_dict
+        ON uni.class = class_dict.class_code
+        AND class_dict.modeling_group IN ('SF', 'MF', 'BB')
     WHERE uni.year IN (
             CAST(YEAR(CURRENT_DATE) - 1 AS VARCHAR),
             CAST(YEAR(CURRENT_DATE) AS VARCHAR)
-        )
-        -- Make sure we only grab parcels valued by the res avm, for the towns
-        -- we're processing.
-        AND uni.class IN (
-            '202', '203', '204', '205', '206', '207', '208', '209',
-            '210', '211', '212', '218', '219', '234', '278', '295'
         )
         AND uni.township_code IN ({dr_towns*}) -- noqa
 )

--- a/provisional-ratio-curves/provisional-ratio-curves.sql
+++ b/provisional-ratio-curves/provisional-ratio-curves.sql
@@ -45,6 +45,13 @@ most_recent_pin AS (
             CAST(YEAR(CURRENT_DATE) - 1 AS VARCHAR),
             CAST(YEAR(CURRENT_DATE) AS VARCHAR)
         )
+        -- Make sure we only grab parcels valued by the res avm, for the towns
+        -- we're processing.
+        AND uni.class IN (
+            '202', '203', '204', '205', '206', '207', '208', '209',
+            '210', '211', '212', '218', '219', '234', '278', '295'
+        )
+        AND uni.township_code IN ({dr_towns*}) -- noqa
 )
 
 SELECT


### PR DESCRIPTION
Desk review has started excluding pins from the desk review values they provide us that they feel are associated with bad sales. While this is fine in the context of internal analysis of desk review, I believe we should be diligent about recording which sales have been excluded so that no one looking at this data in the future is under the impression that these analyses used the same sales sample the model did for predicting values.

It's possible this isn't the ultimate method valuations will employ for sales exclusion, but these updates should be agnostic of however else valuations might want to do this.

I ran the script with these updates and output can be found here: O:\CCAODATA\recurring-data-requests\provisional-ratio-curves\output\2026