### PR TITLE
Limit sale exlucsion indicator to sales

### DIFF
--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -77,11 +77,7 @@ all_ratios <- dr_vals %>%
   # Define an excluded sale as one that has a sale price but no provided desk
   # review value.
   mutate(
-    sale_excluded = case_when(
-      is.na(sale_price) ~ NA,
-      is.na(desk_review_value) & !is.na(sale_price) ~ TRUE,
-      TRUE ~ FALSE
-    )
+    sale_excluded = if_else(is.na(sale_price), NA, is.na(desk_review_value))
   )
 
 walk(unique(all_ratios$township_name), \(x) {

--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -76,7 +76,13 @@ all_ratios <- dr_vals %>%
   full_join(model_vals, by = "pin") %>%
   # Define an excluded sale as one that has a sale price but no provided desk
   # review value.
-  mutate(sale_excluded = is.na(desk_review_value) & !is.na(sale_price))
+  mutate(
+    sale_excluded = case_when(
+      is.na(sale_price) ~ NA,
+      is.na(desk_review_value) & !is.na(sale_price) ~ TRUE,
+      TRUE ~ FALSE
+    )
+  )
 
 walk(unique(all_ratios$township_name), \(x) {
   # Construct list for outputting multisheet .xlsx


### PR DESCRIPTION
Fast follow for https://github.com/ccao-data/recurring-data-requests/pull/14. Nothing logically wrong with that PR, just realized while reviewing output there's no reason to mark every non-sale row `FALSE` for `Sale Excluded`.

Sorry for the extra work!