### PR TITLE
Improve deciles for ratio curves

### DIFF
--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -87,7 +87,10 @@ walk(unique(all_ratios$township_name), \(x) {
     filter(township_name == x) %>%
     select(-township_name) %>%
     mutate(
-      price_decile = ntile(na_if(sale_excluded, TRUE), 10),
+      price_decile = ntile(
+        if_else(sale_excluded %in% TRUE, NA_real_, sale_price),
+        10
+      ),
       model_sale_ratio = model_value / sale_price,
       desk_review_sale_ratio = desk_review_value / sale_price
     )

--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -30,8 +30,8 @@ year <- format(Sys.Date(), "%Y")
 # from a local machine. They MUST be named according to the current naming
 # scheme, and there must be PIN and Desk Review Value columns
 data_path <- "O:/CCAODATA/recurring-data-requests/provisional-ratio-curves"
-input_path <- file.path(data_path, "input", year)
-output_path <- file.path(data_path, "output", year)
+input_path <- file.path("input", year)
+output_path <- file.path("output", year)
 files_in <- list.files(input_path, full.names = TRUE, pattern = "\\.xlsx$")
 
 # Flatfile ----
@@ -87,14 +87,14 @@ walk(unique(all_ratios$township_name), \(x) {
     filter(township_name == x) %>%
     select(-township_name) %>%
     mutate(
-      price_decile = ntile(sale_price, 10),
+      price_decile = ntile(if_else(sale_excluded %in% TRUE, NA_real_, sale_price), 10),
       model_sale_ratio = model_value / sale_price,
       desk_review_sale_ratio = desk_review_value / sale_price
     )
 
   # Summarize ratios and price ranges by decile for .xlsx output
   output$`Ratio Deciles` <- output$`All Parcels` %>%
-    filter(!is.na(sale_price)) %>%
+    filter(!is.na(sale_price), !sale_excluded) %>%
     summarize(
       model_ratio = median(model_sale_ratio),
       model_cod = assessr::cod(model_sale_ratio),
@@ -114,7 +114,7 @@ walk(unique(all_ratios$township_name), \(x) {
 
   # Calculate vertical equity metrics for .xlsx output
   output$`Town-Level Stats` <- output$`All Parcels` %>%
-    filter(!is.na(sale_price)) %>%
+    filter(!is.na(sale_price), !sale_excluded) %>%
     summarize(
       model_ratio = median(model_sale_ratio),
       model_cod = assessr::cod(model_sale_ratio),
@@ -153,7 +153,7 @@ walk(unique(all_ratios$township_name), \(x) {
 
   # Build x-axis labels with abbreviated price ranges per decile
   axis_labels <- output$`All Parcels` %>%
-    filter(!is.na(`Sale Price`)) %>%
+    filter(!is.na(`Sale Price`), !is.na(`Price Decile`)) %>%
     summarize(
       min_price = min(`Sale Price`),
       max_price = max(`Sale Price`),
@@ -229,6 +229,7 @@ walk(unique(all_ratios$township_name), \(x) {
     select(town_nbhd, geometry)
 
   map_data <- output$`All Parcels` %>%
+    filter(!`Sale Excluded` %in% TRUE) %>%
     select(
       `Neighborhood Number`,
       `Model Sale Ratio`,

--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -88,7 +88,8 @@ walk(unique(all_ratios$township_name), \(x) {
     select(-township_name) %>%
     mutate(
       price_decile = ntile(if_else(sale_excluded %in% TRUE,
-        NA_real_, sale_price), 10),
+        NA_real_, sale_price
+      ), 10),
       model_sale_ratio = model_value / sale_price,
       desk_review_sale_ratio = desk_review_value / sale_price
     )

--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -30,8 +30,8 @@ year <- format(Sys.Date(), "%Y")
 # from a local machine. They MUST be named according to the current naming
 # scheme, and there must be PIN and Desk Review Value columns
 data_path <- "O:/CCAODATA/recurring-data-requests/provisional-ratio-curves"
-input_path <- file.path("input", year)
-output_path <- file.path("output", year)
+input_path <- file.path(data_path, "input", year)
+output_path <- file.path(data_path, "output", year)
 files_in <- list.files(input_path, full.names = TRUE, pattern = "\\.xlsx$")
 
 # Flatfile ----

--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -156,7 +156,7 @@ walk(unique(all_ratios$township_name), \(x) {
 
   # Build x-axis labels with abbreviated price ranges per decile
   axis_labels <- output$`All Parcels` %>%
-    filter(!is.na(`Sale Price`), !is.na(`Price Decile`)) %>%
+    filter(!is.na(`Sale Price`), !`Sale Excluded`) %>%
     summarize(
       min_price = min(`Sale Price`),
       max_price = max(`Sale Price`),

--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -87,7 +87,8 @@ walk(unique(all_ratios$township_name), \(x) {
     filter(township_name == x) %>%
     select(-township_name) %>%
     mutate(
-      price_decile = ntile(if_else(sale_excluded %in% TRUE, NA_real_, sale_price), 10),
+      price_decile = ntile(if_else(sale_excluded %in% TRUE,
+        NA_real_, sale_price), 10),
       model_sale_ratio = model_value / sale_price,
       desk_review_sale_ratio = desk_review_value / sale_price
     )

--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -87,9 +87,10 @@ walk(unique(all_ratios$township_name), \(x) {
     filter(township_name == x) %>%
     select(-township_name) %>%
     mutate(
-      price_decile = ntile(if_else(sale_excluded %in% TRUE,
-        NA_real_, sale_price
-      ), 10),
+      price_decile = ntile(
+        if_else(sale_excluded %in% TRUE, NA_real_, sale_price),
+        10
+      ),
       model_sale_ratio = model_value / sale_price,
       desk_review_sale_ratio = desk_review_value / sale_price
     )

--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -232,7 +232,7 @@ walk(unique(all_ratios$township_name), \(x) {
     select(town_nbhd, geometry)
 
   map_data <- output$`All Parcels` %>%
-    filter(!`Sale Excluded` %in% TRUE) %>%
+    filter(!isTRUE(`Sale Excluded`)) %>%
     select(
       `Neighborhood Number`,
       `Model Sale Ratio`,

--- a/provisional-ratio-curves/provisional-ratio-curves.R
+++ b/provisional-ratio-curves/provisional-ratio-curves.R
@@ -87,10 +87,7 @@ walk(unique(all_ratios$township_name), \(x) {
     filter(township_name == x) %>%
     select(-township_name) %>%
     mutate(
-      price_decile = ntile(
-        if_else(sale_excluded %in% TRUE, NA_real_, sale_price),
-        10
-      ),
+      price_decile = ntile(na_if(sale_excluded, TRUE), 10),
       model_sale_ratio = model_value / sale_price,
       desk_review_sale_ratio = desk_review_value / sale_price
     )

--- a/provisional-ratio-curves/renv.lock
+++ b/provisional-ratio-curves/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.5.1",
+    "Version": "4.6.1",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -11,14 +11,14 @@
   "Packages": {
     "DBI": {
       "Package": "DBI",
-      "Version": "1.2.3",
+      "Version": "1.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "065ae649b05f1ff66bb0c793107508f5"
+      "Hash": "dbfa2adb83f8063640982459e153f650"
     },
     "KernSmooth": {
       "Package": "KernSmooth",
@@ -68,31 +68,32 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.1.0",
+      "Version": "1.1.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
+        "R",
         "methods",
         "utils"
       ],
-      "Hash": "0d3d8867aa41b0d9ad113b50c169ecb2"
+      "Hash": "f481f89daa906a34eab8ef8658c8a89c"
     },
     "S7": {
       "Package": "S7",
-      "Version": "0.2.0",
+      "Version": "0.2.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "5deb66b3ae702137e1f4162c11861e76"
+      "Hash": "6a72e94a8c9be4ef719af3aa3628f2dc"
     },
     "abind": {
       "Package": "abind",
       "Version": "1.4-8",
       "Source": "Repository",
-      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods",
@@ -102,7 +103,7 @@
     },
     "arrow": {
       "Package": "arrow",
-      "Version": "21.0.0.1",
+      "Version": "25.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -120,7 +121,7 @@
         "utils",
         "vctrs"
       ],
-      "Hash": "ef54a31808517d2197e83dd57ca391e5"
+      "Hash": "d8c220599be46a5d07f6837e715bfe13"
     },
     "askpass": {
       "Package": "askpass",
@@ -151,22 +152,22 @@
       "RemoteUsername": "ccao-data",
       "RemoteRepo": "assessr",
       "RemoteRef": "master",
-      "RemoteSha": "ddc5799e912eefb6caa1cc8da24e11beb7c052f6",
+      "RemoteSha": "f1b2cdaa4fd5bc9d1597b9fe9537dc48d34e4a80",
       "Requirements": [
         "R",
         "stats"
       ],
-      "Hash": "f23830de8c4b1e169fe1e44d769a6583"
+      "Hash": "e533ff8176cf00d0fec973ae645098a4"
     },
     "base64enc": {
       "Package": "base64enc",
-      "Version": "0.1-3",
+      "Version": "0.1-6",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "543776ae6848fde2f48ff3816d0628bc"
+      "Hash": "5edb675b7baa6e9a0d86dd2c28de1676"
     },
     "bit": {
       "Package": "bit",
@@ -180,7 +181,7 @@
     },
     "bit64": {
       "Package": "bit64",
-      "Version": "4.6.0-1",
+      "Version": "4.8.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -191,27 +192,30 @@
         "stats",
         "utils"
       ],
-      "Hash": "4f572fbc586294afff277db583b9060f"
+      "Hash": "71778c0b60bbf439ac64e6a8be695917"
     },
     "ccao": {
       "Package": "ccao",
       "Version": "1.3.1",
       "Source": "GitHub",
       "RemoteType": "github",
+      "RemoteHost": "api.github.com",
       "RemoteUsername": "ccao-data",
       "RemoteRepo": "ccao",
       "RemoteRef": "master",
-      "RemoteSha": "18e12ca5115741924a58b0be6b4055f480f22a2d",
-      "RemoteHost": "api.github.com",
+      "RemoteSha": "419b67731a1aeb1fa1d2b47b0ed6c3391f5c653a",
       "Requirements": [
         "R",
+        "arrow",
         "assessr",
         "dplyr",
+        "glue",
         "magrittr",
+        "noctua",
         "rlang",
         "tidyr"
       ],
-      "Hash": "c4c334d304550bbf4736eee6a4f15592"
+      "Hash": "f05c4f99a56189cac0a30f11cc05dbf3"
     },
     "class": {
       "Package": "class",
@@ -230,7 +234,7 @@
       "Package": "classInt",
       "Version": "0.4-11",
       "Source": "Repository",
-      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+      "Repository": "CRAN",
       "Requirements": [
         "KernSmooth",
         "R",
@@ -244,30 +248,20 @@
     },
     "cli": {
       "Package": "cli",
-      "Version": "3.6.5",
+      "Version": "3.6.6",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "16850760556401a2eeb27d39bd11c9cb"
-    },
-    "clipr": {
-      "Package": "clipr",
-      "Version": "0.8.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "utils"
-      ],
-      "Hash": "3f038e5ac7f41d4ac41ce658c85e3042"
+      "Hash": "a73d822b669d443ff8de6928f9c49850"
     },
     "colorspace": {
       "Package": "colorspace",
-      "Version": "2.1-2",
+      "Version": "2.1-3",
       "Source": "Repository",
-      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "grDevices",
@@ -275,17 +269,17 @@
         "methods",
         "stats"
       ],
-      "Hash": "2c14b873da71cacec1284f3f6d112ddc"
+      "Hash": "acb51c45a64447d9deb5e4d5c9e0de9e"
     },
     "cpp11": {
       "Package": "cpp11",
-      "Version": "0.5.2",
+      "Version": "0.5.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "2720e3fd3dad08f34b19b56b3d6f073d"
+      "Hash": "20ecb9105a3fb48a8390919abc3b7e90"
     },
     "crayon": {
       "Package": "crayon",
@@ -301,39 +295,39 @@
     },
     "curl": {
       "Package": "curl",
-      "Version": "7.0.0",
+      "Version": "7.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "aa27e963d3deccf4bade44d06b976977"
+      "Hash": "2e004ed19964915a8faf48a574439be9"
     },
     "data.table": {
       "Package": "data.table",
-      "Version": "1.17.8",
+      "Version": "1.18.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "1d991cd6160fa7b1fdbd3689034cbd15"
+      "Hash": "da9ddede68a6f6e5d3098c0ab81b6e1f"
     },
     "digest": {
       "Package": "digest",
-      "Version": "0.6.37",
+      "Version": "0.6.39",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "33698c4b3127fc9f506654607fb73676"
+      "Hash": "d18028e978a88b2b16ef8d400cb49adf"
     },
     "dplyr": {
       "Package": "dplyr",
-      "Version": "1.1.4",
+      "Version": "1.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -352,13 +346,13 @@
         "utils",
         "vctrs"
       ],
-      "Hash": "fedd9d00c2944ff00a0e2696ccf048ec"
+      "Hash": "d71f190466b9496cf8543c76641be5cf"
     },
     "e1071": {
       "Package": "e1071",
-      "Version": "1.7-16",
+      "Version": "1.7-17",
       "Source": "Repository",
-      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+      "Repository": "CRAN",
       "Requirements": [
         "class",
         "grDevices",
@@ -368,7 +362,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "27a09ca40266a1066d62ef5402dd51d6"
+      "Hash": "9d516dde384526d4784166f888cd2c6c"
     },
     "farver": {
       "Package": "farver",
@@ -390,7 +384,7 @@
     },
     "ggplot2": {
       "Package": "ggplot2",
-      "Version": "4.0.0",
+      "Version": "4.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -408,13 +402,13 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "3b4625a157bcbd82b937fcb3acdd2d85"
+      "Hash": "98520fe6b2745c466dca8e46aaa86242"
     },
     "ggspatial": {
       "Package": "ggspatial",
       "Version": "1.1.10",
       "Source": "Repository",
-      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "abind",
@@ -433,14 +427,14 @@
     },
     "glue": {
       "Package": "glue",
-      "Version": "1.8.0",
+      "Version": "1.8.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "5899f1eaa825580172bb56c08266f37c"
+      "Hash": "f8122473e9a49e00d0642f78235ca5e3"
     },
     "gtable": {
       "Package": "gtable",
@@ -473,24 +467,9 @@
       ],
       "Hash": "2799ac720626cec589478b191e48b88b"
     },
-    "httr": {
-      "Package": "httr",
-      "Version": "1.4.7",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "R6",
-        "curl",
-        "jsonlite",
-        "mime",
-        "openssl"
-      ],
-      "Hash": "ac107251d9d9fd72f0ca8049988f1d7f"
-    },
     "httr2": {
       "Package": "httr2",
-      "Version": "1.2.1",
+      "Version": "1.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -502,23 +481,25 @@
         "lifecycle",
         "magrittr",
         "openssl",
-        "rappdirs",
         "rlang",
         "vctrs",
         "withr"
       ],
-      "Hash": "6e29f1ed132b927f7d52e9fd8869f0ea"
+      "Hash": "f4d796ba71b073f7bc95da858caded00"
     },
     "isoband": {
       "Package": "isoband",
-      "Version": "0.2.7",
+      "Version": "0.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
+        "cli",
+        "cpp11",
         "grid",
+        "rlang",
         "utils"
       ],
-      "Hash": "0080607b4a1a7b28979aecef976d8bc2"
+      "Hash": "0f9a864bbd7ce0232ad05cb76249cc1a"
     },
     "jpeg": {
       "Package": "jpeg",
@@ -553,36 +534,25 @@
     },
     "lifecycle": {
       "Package": "lifecycle",
-      "Version": "1.0.4",
+      "Version": "1.0.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "cli",
-        "glue",
         "rlang"
       ],
-      "Hash": "b8552d117e1b808b09a832f589b79035"
+      "Hash": "36dbfe4fba6c064db50a671a90297c85"
     },
     "magrittr": {
       "Package": "magrittr",
-      "Version": "2.0.4",
+      "Version": "2.0.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "8b3b213aa0c54a0dec254288ccb545d1"
-    },
-    "mime": {
-      "Package": "mime",
-      "Version": "0.13",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "tools"
-      ],
-      "Hash": "0ec19f34c72fab674d8f2b4b1c6410e1"
+      "Hash": "665e77ab6e5f37a7913226d40b324e37"
     },
     "noctua": {
       "Package": "noctua",
@@ -603,34 +573,17 @@
     },
     "openssl": {
       "Package": "openssl",
-      "Version": "2.3.4",
+      "Version": "2.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "askpass"
       ],
-      "Hash": "d5811dade9cd3a34a9038a45f1a59bae"
-    },
-    "openxlsx": {
-      "Package": "openxlsx",
-      "Version": "4.2.8",
-      "Source": "Repository",
-      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
-      "Requirements": [
-        "R",
-        "Rcpp",
-        "grDevices",
-        "methods",
-        "stats",
-        "stringi",
-        "utils",
-        "zip"
-      ],
-      "Hash": "0dae94b258dc5abc4713eacdbbebcb51"
+      "Hash": "6994d1c3ea954f29de6aeca5da95c99d"
     },
     "paws": {
       "Package": "paws",
-      "Version": "0.9.0",
+      "Version": "0.10.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -649,31 +602,31 @@
         "paws.security.identity",
         "paws.storage"
       ],
-      "Hash": "694342c0b4f1a09ea666861bc140cd46"
+      "Hash": "f840835e93f287e6bf79d95f536cdb2f"
     },
     "paws.analytics": {
       "Package": "paws.analytics",
-      "Version": "0.9.0",
+      "Version": "0.10.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "3213419b212594e3d5ba31b92522e493"
+      "Hash": "7d181b30d14ef34589ca20bbb7361fde"
     },
     "paws.application.integration": {
       "Package": "paws.application.integration",
-      "Version": "0.9.0",
+      "Version": "0.10.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "b36a81f2be98e63b209ddebeeea51909"
+      "Hash": "6cde06aeae9f2a6f193886a7756afa7f"
     },
     "paws.common": {
       "Package": "paws.common",
-      "Version": "0.8.5",
+      "Version": "0.8.10",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -689,117 +642,117 @@
         "utils",
         "xml2"
       ],
-      "Hash": "988d9d011a6f6fe5063f0be358047ffb"
+      "Hash": "39e4ac3a7ca67421d5f6b6f5ed2340b9"
     },
     "paws.compute": {
       "Package": "paws.compute",
-      "Version": "0.9.0",
+      "Version": "0.10.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "b6f7689860e23aad2722a15790999bc9"
+      "Hash": "ae63fc9e22e25b5f7d69bf6a62c6a2bb"
     },
     "paws.cost.management": {
       "Package": "paws.cost.management",
-      "Version": "0.9.0",
+      "Version": "0.10.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "cbf7124973cff04a96c5dc75d380ba2a"
+      "Hash": "f239556e7261d7e6036d882ae6cf1c39"
     },
     "paws.customer.engagement": {
       "Package": "paws.customer.engagement",
-      "Version": "0.9.0",
+      "Version": "0.10.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "f6ffb43e3600734f4407fdb2624a2f8a"
+      "Hash": "07280ba6a6878f004297a1e00ad7a26f"
     },
     "paws.database": {
       "Package": "paws.database",
-      "Version": "0.9.0",
+      "Version": "0.10.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "aeebf8b9c74940263f873492fd2206f3"
+      "Hash": "bdf105fa60f5705a47643ee8fd897500"
     },
     "paws.developer.tools": {
       "Package": "paws.developer.tools",
-      "Version": "0.9.0",
+      "Version": "0.10.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "162420e68b0d68235893e3a85255e08b"
+      "Hash": "ec39a93b14e132a19dd50ff439f821de"
     },
     "paws.end.user.computing": {
       "Package": "paws.end.user.computing",
-      "Version": "0.9.0",
+      "Version": "0.10.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "33c2424c8606acae8064af2dc1c2f017"
+      "Hash": "92a5c132a8a378e98028fdaf0cd71a27"
     },
     "paws.machine.learning": {
       "Package": "paws.machine.learning",
-      "Version": "0.9.0",
+      "Version": "0.10.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "925b45f2b6ee221271d8cf25f7a5f1f7"
+      "Hash": "9cb6408161e048927bbbdff3d8765d62"
     },
     "paws.management": {
       "Package": "paws.management",
-      "Version": "0.9.0",
+      "Version": "0.10.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "a4720ad47b2f3073370ec0c18de1cbf5"
+      "Hash": "b114e36c4090bb299408958c785856a8"
     },
     "paws.networking": {
       "Package": "paws.networking",
-      "Version": "0.9.0",
+      "Version": "0.10.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "da9b0f0c9663cb049be40b4aaf1b9af6"
+      "Hash": "92bea219331b4cbfe790ac56dd92ec0a"
     },
     "paws.security.identity": {
       "Package": "paws.security.identity",
-      "Version": "0.9.0",
+      "Version": "0.10.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "8544aa9e403357d7af332d86126f0b85"
+      "Hash": "0667aa70df94a5d303440420ca56c0f8"
     },
     "paws.storage": {
       "Package": "paws.storage",
-      "Version": "0.9.0",
+      "Version": "0.10.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "e6735db72fe328ce12c044c95cf325cb"
+      "Hash": "7dc3b787d34451ee84b1e1d60f245fe4"
     },
     "pillar": {
       "Package": "pillar",
@@ -827,39 +780,15 @@
       ],
       "Hash": "01f28d4278f15c76cddbea05899c5d6f"
     },
-    "plyr": {
-      "Package": "plyr",
-      "Version": "1.8.9",
-      "Source": "Repository",
-      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
-      "Requirements": [
-        "R",
-        "Rcpp"
-      ],
-      "Hash": "6b8177fd19982f0020743fadbfdbd933"
-    },
     "png": {
       "Package": "png",
-      "Version": "0.1-8",
+      "Version": "0.1-9",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "bd54ba8a0a5faded999a7aab6e46b374"
-    },
-    "prettymapr": {
-      "Package": "prettymapr",
-      "Version": "0.2.5",
-      "Source": "Repository",
-      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
-      "Requirements": [
-        "digest",
-        "httr",
-        "plyr",
-        "rjson"
-      ],
-      "Hash": "56a976e191eefe5830dfed35b3f77219"
+      "Hash": "961c433971606243a724eb19b1075e60"
     },
     "prettyunits": {
       "Package": "prettyunits",
@@ -887,19 +816,19 @@
     },
     "proxy": {
       "Package": "proxy",
-      "Version": "0.4-27",
+      "Version": "0.4-29",
       "Source": "Repository",
-      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "stats",
         "utils"
       ],
-      "Hash": "e0ef355c12942cf7a6b91a6cfaea8b3e"
+      "Hash": "b6c826e897b46b163c51a3b990113a21"
     },
     "purrr": {
       "Package": "purrr",
-      "Version": "1.1.0",
+      "Version": "1.2.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -910,40 +839,7 @@
         "rlang",
         "vctrs"
       ],
-      "Hash": "9240cfb47489133f809918a0d3cc60cb"
-    },
-    "rappdirs": {
-      "Package": "rappdirs",
-      "Version": "0.3.3",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
-      "Hash": "5e3c5dc0b071b21fa128676560dbe94d"
-    },
-    "readr": {
-      "Package": "readr",
-      "Version": "2.1.5",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "R6",
-        "cli",
-        "clipr",
-        "cpp11",
-        "crayon",
-        "hms",
-        "lifecycle",
-        "methods",
-        "rlang",
-        "tibble",
-        "tzdb",
-        "utils",
-        "vroom"
-      ],
-      "Hash": "9de96463d2117f6ac49980577939dfb3"
+      "Hash": "0a35605539b085a4828ec55ad973fe60"
     },
     "renv": {
       "Package": "renv",
@@ -955,32 +851,22 @@
       ],
       "Hash": "770fcbc2c4616e8fbcb187cccd46a6b1"
     },
-    "rjson": {
-      "Package": "rjson",
-      "Version": "0.2.23",
-      "Source": "Repository",
-      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
-      "Requirements": [
-        "R"
-      ],
-      "Hash": "7a04e9eff95857dbf557b4e5f0b3d1a8"
-    },
     "rlang": {
       "Package": "rlang",
-      "Version": "1.1.6",
+      "Version": "1.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "892124978869b74935dc3934c42bfe5a"
+      "Hash": "8d05afdb0b0dd5ef01b306db289fe21f"
     },
     "rosm": {
       "Package": "rosm",
-      "Version": "0.3.0",
+      "Version": "0.3.1",
       "Source": "Repository",
-      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+      "Repository": "CRAN",
       "Requirements": [
         "curl",
         "glue",
@@ -990,19 +876,19 @@
         "rlang",
         "wk"
       ],
-      "Hash": "fcd529f183c4163a91430d7b7bbaece5"
+      "Hash": "14c0023fdb16dddf88fd43b321dd1948"
     },
     "s2": {
       "Package": "s2",
-      "Version": "1.1.9",
+      "Version": "1.1.11",
       "Source": "Repository",
-      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "Rcpp",
         "wk"
       ],
-      "Hash": "4e664a5d610d58f27ec196e96cdb7f6f"
+      "Hash": "54b09824b3ac78eb4fa44f76c0616131"
     },
     "scales": {
       "Package": "scales",
@@ -1025,9 +911,9 @@
     },
     "sf": {
       "Package": "sf",
-      "Version": "1.0-21",
+      "Version": "1.1-2",
       "Source": "Repository",
-      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+      "Repository": "CRAN",
       "Requirements": [
         "DBI",
         "R",
@@ -1036,7 +922,6 @@
         "grDevices",
         "graphics",
         "grid",
-        "magrittr",
         "methods",
         "s2",
         "stats",
@@ -1044,7 +929,7 @@
         "units",
         "utils"
       ],
-      "Hash": "14a8dae2a678fa953907893a9df561c0"
+      "Hash": "02483c8ee4115581472646cd5d5984d9"
     },
     "stringi": {
       "Package": "stringi",
@@ -1061,7 +946,7 @@
     },
     "stringr": {
       "Package": "stringr",
-      "Version": "1.5.2",
+      "Version": "1.6.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1074,7 +959,7 @@
         "stringi",
         "vctrs"
       ],
-      "Hash": "8f28c568a22dde52d2c8b11958776ac2"
+      "Hash": "d47392652eedc68bf916657347ff2526"
     },
     "sys": {
       "Package": "sys",
@@ -1085,7 +970,7 @@
     },
     "tibble": {
       "Package": "tibble",
-      "Version": "3.3.0",
+      "Version": "3.3.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1100,11 +985,11 @@
         "utils",
         "vctrs"
       ],
-      "Hash": "784b27d0801c3829de602105757b2cd7"
+      "Hash": "c55df870972551cac674b50cadb2d51f"
     },
     "tidyr": {
       "Package": "tidyr",
-      "Version": "1.3.1",
+      "Version": "1.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1123,7 +1008,7 @@
         "utils",
         "vctrs"
       ],
-      "Hash": "915fb7ce036c22a6a33b5a8adb712eb1"
+      "Hash": "a4fa2f5876396f04814cb9d8d9ab89e9"
     },
     "tidyselect": {
       "Package": "tidyselect",
@@ -1141,27 +1026,16 @@
       ],
       "Hash": "829f27b9c4919c16b593794a6344d6c0"
     },
-    "tzdb": {
-      "Package": "tzdb",
-      "Version": "0.5.0",
+    "units": {
+      "Package": "units",
+      "Version": "1.0-1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
-        "cpp11"
-      ],
-      "Hash": "09e3961e87b7bafa4a9340bbb34aeda8"
-    },
-    "units": {
-      "Package": "units",
-      "Version": "1.0-0",
-      "Source": "Repository",
-      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
-      "Requirements": [
-        "R",
         "Rcpp"
       ],
-      "Hash": "3797c73fd3bde8b1601a4e1bf53557ac"
+      "Hash": "14743a941151a12449e8af67497c7b96"
     },
     "utf8": {
       "Package": "utf8",
@@ -1175,17 +1049,17 @@
     },
     "uuid": {
       "Package": "uuid",
-      "Version": "1.2-1",
+      "Version": "1.2-2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "34e965e62a41fcafb1ca60e9b142085b"
+      "Hash": "528fc9e90d70a6a115e21164f37b2c64"
     },
     "vctrs": {
       "Package": "vctrs",
-      "Version": "0.6.5",
+      "Version": "0.7.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1195,47 +1069,21 @@
         "lifecycle",
         "rlang"
       ],
-      "Hash": "c03fa420630029418f7e6da3667aac4a"
+      "Hash": "2dcde2d30d3ad67bf1d3a37177457b87"
     },
     "viridisLite": {
       "Package": "viridisLite",
-      "Version": "0.4.2",
+      "Version": "0.4.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "c826c7c4241b6fc89ff55aaea3fa7491"
-    },
-    "vroom": {
-      "Package": "vroom",
-      "Version": "1.6.6",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "bit64",
-        "cli",
-        "cpp11",
-        "crayon",
-        "glue",
-        "hms",
-        "lifecycle",
-        "methods",
-        "progress",
-        "rlang",
-        "stats",
-        "tibble",
-        "tidyselect",
-        "tzdb",
-        "vctrs",
-        "withr"
-      ],
-      "Hash": "a9d1c6bf67f15a0d07be840caeaab49a"
+      "Hash": "9380d36888b72faf5ae6c22b44703867"
     },
     "withr": {
       "Package": "withr",
-      "Version": "3.0.2",
+      "Version": "3.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1243,21 +1091,21 @@
         "grDevices",
         "graphics"
       ],
-      "Hash": "cc2d62c76458d425210d1eb1478b30b4"
+      "Hash": "d979712ec72df779bc2d30bcc5d0d541"
     },
     "wk": {
       "Package": "wk",
-      "Version": "0.9.4",
+      "Version": "0.9.5",
       "Source": "Repository",
-      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "37be35d733130f1de1ef51672cf7cdc0"
+      "Hash": "10fb21ed42dbd4ed9162aaab818146e3"
     },
     "xml2": {
       "Package": "xml2",
-      "Version": "1.4.0",
+      "Version": "1.6.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1266,14 +1114,7 @@
         "methods",
         "rlang"
       ],
-      "Hash": "3dfd9ffbe221af775cb37f95e7e893ec"
-    },
-    "zip": {
-      "Package": "zip",
-      "Version": "2.3.3",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "6ebe4b1dc74c3e50e74e316323629583"
+      "Hash": "568fe669c645b2007e4e8fcf5cde40e7"
     }
   }
 }

--- a/provisional-ratio-curves/renv.lock
+++ b/provisional-ratio-curves/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.6.1",
+    "Version": "4.5.1",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -11,14 +11,14 @@
   "Packages": {
     "DBI": {
       "Package": "DBI",
-      "Version": "1.3.0",
+      "Version": "1.2.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "dbfa2adb83f8063640982459e153f650"
+      "Hash": "065ae649b05f1ff66bb0c793107508f5"
     },
     "KernSmooth": {
       "Package": "KernSmooth",
@@ -68,32 +68,31 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.1.2",
+      "Version": "1.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
-        "R",
         "methods",
         "utils"
       ],
-      "Hash": "f481f89daa906a34eab8ef8658c8a89c"
+      "Hash": "0d3d8867aa41b0d9ad113b50c169ecb2"
     },
     "S7": {
       "Package": "S7",
-      "Version": "0.2.2",
+      "Version": "0.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "6a72e94a8c9be4ef719af3aa3628f2dc"
+      "Hash": "5deb66b3ae702137e1f4162c11861e76"
     },
     "abind": {
       "Package": "abind",
       "Version": "1.4-8",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
       "Requirements": [
         "R",
         "methods",
@@ -103,7 +102,7 @@
     },
     "arrow": {
       "Package": "arrow",
-      "Version": "25.0.0",
+      "Version": "21.0.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -121,7 +120,7 @@
         "utils",
         "vctrs"
       ],
-      "Hash": "d8c220599be46a5d07f6837e715bfe13"
+      "Hash": "ef54a31808517d2197e83dd57ca391e5"
     },
     "askpass": {
       "Package": "askpass",
@@ -152,22 +151,22 @@
       "RemoteUsername": "ccao-data",
       "RemoteRepo": "assessr",
       "RemoteRef": "master",
-      "RemoteSha": "f1b2cdaa4fd5bc9d1597b9fe9537dc48d34e4a80",
+      "RemoteSha": "ddc5799e912eefb6caa1cc8da24e11beb7c052f6",
       "Requirements": [
         "R",
         "stats"
       ],
-      "Hash": "e533ff8176cf00d0fec973ae645098a4"
+      "Hash": "f23830de8c4b1e169fe1e44d769a6583"
     },
     "base64enc": {
       "Package": "base64enc",
-      "Version": "0.1-6",
+      "Version": "0.1-3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "5edb675b7baa6e9a0d86dd2c28de1676"
+      "Hash": "543776ae6848fde2f48ff3816d0628bc"
     },
     "bit": {
       "Package": "bit",
@@ -181,7 +180,7 @@
     },
     "bit64": {
       "Package": "bit64",
-      "Version": "4.8.2",
+      "Version": "4.6.0-1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -192,30 +191,27 @@
         "stats",
         "utils"
       ],
-      "Hash": "71778c0b60bbf439ac64e6a8be695917"
+      "Hash": "4f572fbc586294afff277db583b9060f"
     },
     "ccao": {
       "Package": "ccao",
       "Version": "1.3.1",
       "Source": "GitHub",
       "RemoteType": "github",
-      "RemoteHost": "api.github.com",
       "RemoteUsername": "ccao-data",
       "RemoteRepo": "ccao",
       "RemoteRef": "master",
-      "RemoteSha": "419b67731a1aeb1fa1d2b47b0ed6c3391f5c653a",
+      "RemoteSha": "18e12ca5115741924a58b0be6b4055f480f22a2d",
+      "RemoteHost": "api.github.com",
       "Requirements": [
         "R",
-        "arrow",
         "assessr",
         "dplyr",
-        "glue",
         "magrittr",
-        "noctua",
         "rlang",
         "tidyr"
       ],
-      "Hash": "f05c4f99a56189cac0a30f11cc05dbf3"
+      "Hash": "c4c334d304550bbf4736eee6a4f15592"
     },
     "class": {
       "Package": "class",
@@ -234,7 +230,7 @@
       "Package": "classInt",
       "Version": "0.4-11",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
       "Requirements": [
         "KernSmooth",
         "R",
@@ -248,20 +244,30 @@
     },
     "cli": {
       "Package": "cli",
-      "Version": "3.6.6",
+      "Version": "3.6.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "a73d822b669d443ff8de6928f9c49850"
+      "Hash": "16850760556401a2eeb27d39bd11c9cb"
+    },
+    "clipr": {
+      "Package": "clipr",
+      "Version": "0.8.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "utils"
+      ],
+      "Hash": "3f038e5ac7f41d4ac41ce658c85e3042"
     },
     "colorspace": {
       "Package": "colorspace",
-      "Version": "2.1-3",
+      "Version": "2.1-2",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
       "Requirements": [
         "R",
         "grDevices",
@@ -269,17 +275,17 @@
         "methods",
         "stats"
       ],
-      "Hash": "acb51c45a64447d9deb5e4d5c9e0de9e"
+      "Hash": "2c14b873da71cacec1284f3f6d112ddc"
     },
     "cpp11": {
       "Package": "cpp11",
-      "Version": "0.5.5",
+      "Version": "0.5.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "20ecb9105a3fb48a8390919abc3b7e90"
+      "Hash": "2720e3fd3dad08f34b19b56b3d6f073d"
     },
     "crayon": {
       "Package": "crayon",
@@ -295,39 +301,39 @@
     },
     "curl": {
       "Package": "curl",
-      "Version": "7.1.0",
+      "Version": "7.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "2e004ed19964915a8faf48a574439be9"
+      "Hash": "aa27e963d3deccf4bade44d06b976977"
     },
     "data.table": {
       "Package": "data.table",
-      "Version": "1.18.4",
+      "Version": "1.17.8",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "da9ddede68a6f6e5d3098c0ab81b6e1f"
+      "Hash": "1d991cd6160fa7b1fdbd3689034cbd15"
     },
     "digest": {
       "Package": "digest",
-      "Version": "0.6.39",
+      "Version": "0.6.37",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "d18028e978a88b2b16ef8d400cb49adf"
+      "Hash": "33698c4b3127fc9f506654607fb73676"
     },
     "dplyr": {
       "Package": "dplyr",
-      "Version": "1.2.1",
+      "Version": "1.1.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -346,13 +352,13 @@
         "utils",
         "vctrs"
       ],
-      "Hash": "d71f190466b9496cf8543c76641be5cf"
+      "Hash": "fedd9d00c2944ff00a0e2696ccf048ec"
     },
     "e1071": {
       "Package": "e1071",
-      "Version": "1.7-17",
+      "Version": "1.7-16",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
       "Requirements": [
         "class",
         "grDevices",
@@ -362,7 +368,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "9d516dde384526d4784166f888cd2c6c"
+      "Hash": "27a09ca40266a1066d62ef5402dd51d6"
     },
     "farver": {
       "Package": "farver",
@@ -384,7 +390,7 @@
     },
     "ggplot2": {
       "Package": "ggplot2",
-      "Version": "4.0.3",
+      "Version": "4.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -402,13 +408,13 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "98520fe6b2745c466dca8e46aaa86242"
+      "Hash": "3b4625a157bcbd82b937fcb3acdd2d85"
     },
     "ggspatial": {
       "Package": "ggspatial",
       "Version": "1.1.10",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
       "Requirements": [
         "R",
         "abind",
@@ -427,14 +433,14 @@
     },
     "glue": {
       "Package": "glue",
-      "Version": "1.8.1",
+      "Version": "1.8.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "f8122473e9a49e00d0642f78235ca5e3"
+      "Hash": "5899f1eaa825580172bb56c08266f37c"
     },
     "gtable": {
       "Package": "gtable",
@@ -467,9 +473,24 @@
       ],
       "Hash": "2799ac720626cec589478b191e48b88b"
     },
+    "httr": {
+      "Package": "httr",
+      "Version": "1.4.7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "R6",
+        "curl",
+        "jsonlite",
+        "mime",
+        "openssl"
+      ],
+      "Hash": "ac107251d9d9fd72f0ca8049988f1d7f"
+    },
     "httr2": {
       "Package": "httr2",
-      "Version": "1.3.0",
+      "Version": "1.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -481,25 +502,23 @@
         "lifecycle",
         "magrittr",
         "openssl",
+        "rappdirs",
         "rlang",
         "vctrs",
         "withr"
       ],
-      "Hash": "f4d796ba71b073f7bc95da858caded00"
+      "Hash": "6e29f1ed132b927f7d52e9fd8869f0ea"
     },
     "isoband": {
       "Package": "isoband",
-      "Version": "0.3.0",
+      "Version": "0.2.7",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
-        "cli",
-        "cpp11",
         "grid",
-        "rlang",
         "utils"
       ],
-      "Hash": "0f9a864bbd7ce0232ad05cb76249cc1a"
+      "Hash": "0080607b4a1a7b28979aecef976d8bc2"
     },
     "jpeg": {
       "Package": "jpeg",
@@ -534,25 +553,36 @@
     },
     "lifecycle": {
       "Package": "lifecycle",
-      "Version": "1.0.5",
+      "Version": "1.0.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "cli",
+        "glue",
         "rlang"
       ],
-      "Hash": "36dbfe4fba6c064db50a671a90297c85"
+      "Hash": "b8552d117e1b808b09a832f589b79035"
     },
     "magrittr": {
       "Package": "magrittr",
-      "Version": "2.0.5",
+      "Version": "2.0.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "665e77ab6e5f37a7913226d40b324e37"
+      "Hash": "8b3b213aa0c54a0dec254288ccb545d1"
+    },
+    "mime": {
+      "Package": "mime",
+      "Version": "0.13",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "tools"
+      ],
+      "Hash": "0ec19f34c72fab674d8f2b4b1c6410e1"
     },
     "noctua": {
       "Package": "noctua",
@@ -573,17 +603,34 @@
     },
     "openssl": {
       "Package": "openssl",
-      "Version": "2.4.2",
+      "Version": "2.3.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "askpass"
       ],
-      "Hash": "6994d1c3ea954f29de6aeca5da95c99d"
+      "Hash": "d5811dade9cd3a34a9038a45f1a59bae"
+    },
+    "openxlsx": {
+      "Package": "openxlsx",
+      "Version": "4.2.8",
+      "Source": "Repository",
+      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+      "Requirements": [
+        "R",
+        "Rcpp",
+        "grDevices",
+        "methods",
+        "stats",
+        "stringi",
+        "utils",
+        "zip"
+      ],
+      "Hash": "0dae94b258dc5abc4713eacdbbebcb51"
     },
     "paws": {
       "Package": "paws",
-      "Version": "0.10.0",
+      "Version": "0.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -602,31 +649,31 @@
         "paws.security.identity",
         "paws.storage"
       ],
-      "Hash": "f840835e93f287e6bf79d95f536cdb2f"
+      "Hash": "694342c0b4f1a09ea666861bc140cd46"
     },
     "paws.analytics": {
       "Package": "paws.analytics",
-      "Version": "0.10.0",
+      "Version": "0.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "7d181b30d14ef34589ca20bbb7361fde"
+      "Hash": "3213419b212594e3d5ba31b92522e493"
     },
     "paws.application.integration": {
       "Package": "paws.application.integration",
-      "Version": "0.10.0",
+      "Version": "0.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "6cde06aeae9f2a6f193886a7756afa7f"
+      "Hash": "b36a81f2be98e63b209ddebeeea51909"
     },
     "paws.common": {
       "Package": "paws.common",
-      "Version": "0.8.10",
+      "Version": "0.8.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -642,117 +689,117 @@
         "utils",
         "xml2"
       ],
-      "Hash": "39e4ac3a7ca67421d5f6b6f5ed2340b9"
+      "Hash": "988d9d011a6f6fe5063f0be358047ffb"
     },
     "paws.compute": {
       "Package": "paws.compute",
-      "Version": "0.10.0",
+      "Version": "0.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "ae63fc9e22e25b5f7d69bf6a62c6a2bb"
+      "Hash": "b6f7689860e23aad2722a15790999bc9"
     },
     "paws.cost.management": {
       "Package": "paws.cost.management",
-      "Version": "0.10.0",
+      "Version": "0.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "f239556e7261d7e6036d882ae6cf1c39"
+      "Hash": "cbf7124973cff04a96c5dc75d380ba2a"
     },
     "paws.customer.engagement": {
       "Package": "paws.customer.engagement",
-      "Version": "0.10.0",
+      "Version": "0.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "07280ba6a6878f004297a1e00ad7a26f"
+      "Hash": "f6ffb43e3600734f4407fdb2624a2f8a"
     },
     "paws.database": {
       "Package": "paws.database",
-      "Version": "0.10.0",
+      "Version": "0.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "bdf105fa60f5705a47643ee8fd897500"
+      "Hash": "aeebf8b9c74940263f873492fd2206f3"
     },
     "paws.developer.tools": {
       "Package": "paws.developer.tools",
-      "Version": "0.10.0",
+      "Version": "0.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "ec39a93b14e132a19dd50ff439f821de"
+      "Hash": "162420e68b0d68235893e3a85255e08b"
     },
     "paws.end.user.computing": {
       "Package": "paws.end.user.computing",
-      "Version": "0.10.0",
+      "Version": "0.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "92a5c132a8a378e98028fdaf0cd71a27"
+      "Hash": "33c2424c8606acae8064af2dc1c2f017"
     },
     "paws.machine.learning": {
       "Package": "paws.machine.learning",
-      "Version": "0.10.0",
+      "Version": "0.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "9cb6408161e048927bbbdff3d8765d62"
+      "Hash": "925b45f2b6ee221271d8cf25f7a5f1f7"
     },
     "paws.management": {
       "Package": "paws.management",
-      "Version": "0.10.0",
+      "Version": "0.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "b114e36c4090bb299408958c785856a8"
+      "Hash": "a4720ad47b2f3073370ec0c18de1cbf5"
     },
     "paws.networking": {
       "Package": "paws.networking",
-      "Version": "0.10.0",
+      "Version": "0.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "92bea219331b4cbfe790ac56dd92ec0a"
+      "Hash": "da9b0f0c9663cb049be40b4aaf1b9af6"
     },
     "paws.security.identity": {
       "Package": "paws.security.identity",
-      "Version": "0.10.0",
+      "Version": "0.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "0667aa70df94a5d303440420ca56c0f8"
+      "Hash": "8544aa9e403357d7af332d86126f0b85"
     },
     "paws.storage": {
       "Package": "paws.storage",
-      "Version": "0.10.0",
+      "Version": "0.9.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "paws.common"
       ],
-      "Hash": "7dc3b787d34451ee84b1e1d60f245fe4"
+      "Hash": "e6735db72fe328ce12c044c95cf325cb"
     },
     "pillar": {
       "Package": "pillar",
@@ -780,15 +827,39 @@
       ],
       "Hash": "01f28d4278f15c76cddbea05899c5d6f"
     },
+    "plyr": {
+      "Package": "plyr",
+      "Version": "1.8.9",
+      "Source": "Repository",
+      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+      "Requirements": [
+        "R",
+        "Rcpp"
+      ],
+      "Hash": "6b8177fd19982f0020743fadbfdbd933"
+    },
     "png": {
       "Package": "png",
-      "Version": "0.1-9",
+      "Version": "0.1-8",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "961c433971606243a724eb19b1075e60"
+      "Hash": "bd54ba8a0a5faded999a7aab6e46b374"
+    },
+    "prettymapr": {
+      "Package": "prettymapr",
+      "Version": "0.2.5",
+      "Source": "Repository",
+      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+      "Requirements": [
+        "digest",
+        "httr",
+        "plyr",
+        "rjson"
+      ],
+      "Hash": "56a976e191eefe5830dfed35b3f77219"
     },
     "prettyunits": {
       "Package": "prettyunits",
@@ -816,19 +887,19 @@
     },
     "proxy": {
       "Package": "proxy",
-      "Version": "0.4-29",
+      "Version": "0.4-27",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
       "Requirements": [
         "R",
         "stats",
         "utils"
       ],
-      "Hash": "b6c826e897b46b163c51a3b990113a21"
+      "Hash": "e0ef355c12942cf7a6b91a6cfaea8b3e"
     },
     "purrr": {
       "Package": "purrr",
-      "Version": "1.2.2",
+      "Version": "1.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -839,7 +910,40 @@
         "rlang",
         "vctrs"
       ],
-      "Hash": "0a35605539b085a4828ec55ad973fe60"
+      "Hash": "9240cfb47489133f809918a0d3cc60cb"
+    },
+    "rappdirs": {
+      "Package": "rappdirs",
+      "Version": "0.3.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "5e3c5dc0b071b21fa128676560dbe94d"
+    },
+    "readr": {
+      "Package": "readr",
+      "Version": "2.1.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "R6",
+        "cli",
+        "clipr",
+        "cpp11",
+        "crayon",
+        "hms",
+        "lifecycle",
+        "methods",
+        "rlang",
+        "tibble",
+        "tzdb",
+        "utils",
+        "vroom"
+      ],
+      "Hash": "9de96463d2117f6ac49980577939dfb3"
     },
     "renv": {
       "Package": "renv",
@@ -851,22 +955,32 @@
       ],
       "Hash": "770fcbc2c4616e8fbcb187cccd46a6b1"
     },
+    "rjson": {
+      "Package": "rjson",
+      "Version": "0.2.23",
+      "Source": "Repository",
+      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "7a04e9eff95857dbf557b4e5f0b3d1a8"
+    },
     "rlang": {
       "Package": "rlang",
-      "Version": "1.3.0",
+      "Version": "1.1.6",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "8d05afdb0b0dd5ef01b306db289fe21f"
+      "Hash": "892124978869b74935dc3934c42bfe5a"
     },
     "rosm": {
       "Package": "rosm",
-      "Version": "0.3.1",
+      "Version": "0.3.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
       "Requirements": [
         "curl",
         "glue",
@@ -876,19 +990,19 @@
         "rlang",
         "wk"
       ],
-      "Hash": "14c0023fdb16dddf88fd43b321dd1948"
+      "Hash": "fcd529f183c4163a91430d7b7bbaece5"
     },
     "s2": {
       "Package": "s2",
-      "Version": "1.1.11",
+      "Version": "1.1.9",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
       "Requirements": [
         "R",
         "Rcpp",
         "wk"
       ],
-      "Hash": "54b09824b3ac78eb4fa44f76c0616131"
+      "Hash": "4e664a5d610d58f27ec196e96cdb7f6f"
     },
     "scales": {
       "Package": "scales",
@@ -911,9 +1025,9 @@
     },
     "sf": {
       "Package": "sf",
-      "Version": "1.1-2",
+      "Version": "1.0-21",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
       "Requirements": [
         "DBI",
         "R",
@@ -922,6 +1036,7 @@
         "grDevices",
         "graphics",
         "grid",
+        "magrittr",
         "methods",
         "s2",
         "stats",
@@ -929,7 +1044,7 @@
         "units",
         "utils"
       ],
-      "Hash": "02483c8ee4115581472646cd5d5984d9"
+      "Hash": "14a8dae2a678fa953907893a9df561c0"
     },
     "stringi": {
       "Package": "stringi",
@@ -946,7 +1061,7 @@
     },
     "stringr": {
       "Package": "stringr",
-      "Version": "1.6.0",
+      "Version": "1.5.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -959,7 +1074,7 @@
         "stringi",
         "vctrs"
       ],
-      "Hash": "d47392652eedc68bf916657347ff2526"
+      "Hash": "8f28c568a22dde52d2c8b11958776ac2"
     },
     "sys": {
       "Package": "sys",
@@ -970,7 +1085,7 @@
     },
     "tibble": {
       "Package": "tibble",
-      "Version": "3.3.1",
+      "Version": "3.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -985,11 +1100,11 @@
         "utils",
         "vctrs"
       ],
-      "Hash": "c55df870972551cac674b50cadb2d51f"
+      "Hash": "784b27d0801c3829de602105757b2cd7"
     },
     "tidyr": {
       "Package": "tidyr",
-      "Version": "1.3.2",
+      "Version": "1.3.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1008,7 +1123,7 @@
         "utils",
         "vctrs"
       ],
-      "Hash": "a4fa2f5876396f04814cb9d8d9ab89e9"
+      "Hash": "915fb7ce036c22a6a33b5a8adb712eb1"
     },
     "tidyselect": {
       "Package": "tidyselect",
@@ -1026,16 +1141,27 @@
       ],
       "Hash": "829f27b9c4919c16b593794a6344d6c0"
     },
-    "units": {
-      "Package": "units",
-      "Version": "1.0-1",
+    "tzdb": {
+      "Package": "tzdb",
+      "Version": "0.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
+        "cpp11"
+      ],
+      "Hash": "09e3961e87b7bafa4a9340bbb34aeda8"
+    },
+    "units": {
+      "Package": "units",
+      "Version": "1.0-0",
+      "Source": "Repository",
+      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+      "Requirements": [
+        "R",
         "Rcpp"
       ],
-      "Hash": "14743a941151a12449e8af67497c7b96"
+      "Hash": "3797c73fd3bde8b1601a4e1bf53557ac"
     },
     "utf8": {
       "Package": "utf8",
@@ -1049,17 +1175,17 @@
     },
     "uuid": {
       "Package": "uuid",
-      "Version": "1.2-2",
+      "Version": "1.2-1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "528fc9e90d70a6a115e21164f37b2c64"
+      "Hash": "34e965e62a41fcafb1ca60e9b142085b"
     },
     "vctrs": {
       "Package": "vctrs",
-      "Version": "0.7.3",
+      "Version": "0.6.5",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1069,21 +1195,47 @@
         "lifecycle",
         "rlang"
       ],
-      "Hash": "2dcde2d30d3ad67bf1d3a37177457b87"
+      "Hash": "c03fa420630029418f7e6da3667aac4a"
     },
     "viridisLite": {
       "Package": "viridisLite",
-      "Version": "0.4.3",
+      "Version": "0.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "9380d36888b72faf5ae6c22b44703867"
+      "Hash": "c826c7c4241b6fc89ff55aaea3fa7491"
+    },
+    "vroom": {
+      "Package": "vroom",
+      "Version": "1.6.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "bit64",
+        "cli",
+        "cpp11",
+        "crayon",
+        "glue",
+        "hms",
+        "lifecycle",
+        "methods",
+        "progress",
+        "rlang",
+        "stats",
+        "tibble",
+        "tidyselect",
+        "tzdb",
+        "vctrs",
+        "withr"
+      ],
+      "Hash": "a9d1c6bf67f15a0d07be840caeaab49a"
     },
     "withr": {
       "Package": "withr",
-      "Version": "3.0.3",
+      "Version": "3.0.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1091,21 +1243,21 @@
         "grDevices",
         "graphics"
       ],
-      "Hash": "d979712ec72df779bc2d30bcc5d0d541"
+      "Hash": "cc2d62c76458d425210d1eb1478b30b4"
     },
     "wk": {
       "Package": "wk",
-      "Version": "0.9.5",
+      "Version": "0.9.4",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
       "Requirements": [
         "R"
       ],
-      "Hash": "10fb21ed42dbd4ed9162aaab818146e3"
+      "Hash": "37be35d733130f1de1ef51672cf7cdc0"
     },
     "xml2": {
       "Package": "xml2",
-      "Version": "1.6.0",
+      "Version": "1.4.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1114,7 +1266,14 @@
         "methods",
         "rlang"
       ],
-      "Hash": "568fe669c645b2007e4e8fcf5cde40e7"
+      "Hash": "3dfd9ffbe221af775cb37f95e7e893ec"
+    },
+    "zip": {
+      "Package": "zip",
+      "Version": "2.3.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6ebe4b1dc74c3e50e74e316323629583"
     }
   }
 }


### PR DESCRIPTION
We were not getting a ratio value for the 1st decile once `excluded sales` were removed from the spreadsheet.

My initial assumption was that we had too few sales in the 1st decile grouping, but I don't think that's right. My next hunch is that it involves NA sales which calculate NA ratios. I'm still investigating this slightly. 

Pretty sure it was in this line
`median(desk_review_sale_ratio)` which doesn't remove NA values.

However, this standardizes all the ratio calculations to remove the sales which res-val include in their exclusion list including the map, ratio stats, and the ratio curve.

I asked when the requestor wanted the file and they said by EOD tomorrow.